### PR TITLE
Fix listener exchange name bug

### DIFF
--- a/lib/hearst/dispatcher.rb
+++ b/lib/hearst/dispatcher.rb
@@ -21,7 +21,7 @@ module Hearst
     end
 
     def exchange
-      @exchange ||= channel.topic(exchange_name)
+      @exchange ||= channel.topic(exchange_name, durable: true, auto_delete: false)
     end
 
     def exchange_name

--- a/lib/hearst/listener.rb
+++ b/lib/hearst/listener.rb
@@ -11,7 +11,7 @@ module Hearst
       connection.start
 
       subscribers.each do |subscriber|
-        queue.bind(channel.topic(subscriber.exchange, routing_key: subscriber.event || exchange_name))
+        queue.bind(exchange_for(subscriber.exchange), routing_key: subscriber.event)
       end
 
       queue.subscribe(manual_ack: true) do |delivery_info, metadata, payload|
@@ -36,6 +36,10 @@ module Hearst
 
     def queue
       @queue ||= channel.queue(exchange_name, durable: true, auto_delete: false)
+    end
+
+    def exchange_for(name)
+      channel.topic(name, durable: true, auto_delete: false)
     end
 
     def exchange_name

--- a/lib/hearst/subscriber.rb
+++ b/lib/hearst/subscriber.rb
@@ -12,7 +12,7 @@ module Hearst
     module ClassMethods
       def subscribes_to(event, exchange: nil)
         self.event = event
-        self.exchange = exchange
+        self.exchange = exchange || ENV['EXCHANGE_NAME']
       end
 
       def process(payload)

--- a/spec/subscriber_spec.rb
+++ b/spec/subscriber_spec.rb
@@ -7,6 +7,11 @@ describe Hearst::Subscriber do
     subscribes_to 'foo.bar', exchange: 'foo-exchange'
   end
 
+  class LocalTestSubscriber
+    include Hearst::Subscriber
+    subscribes_to 'local.foo.bar'
+  end
+
   it 'auto-registers itself with Hearst' do
     expect(Hearst.subscribers).to include(TestSubscriber)
   end
@@ -20,6 +25,10 @@ describe Hearst::Subscriber do
     expect {
       TestSubscriber.process(pay: 'load')
     }.to raise_error(NotImplementedError)
+  end
+
+  it 'defaults to local exchange name from ENV if not declared' do
+    expect(LocalTestSubscriber.exchange).to eq(ENV['EXCHANGE_NAME'])
   end
 
 end


### PR DESCRIPTION
`Hearst::Listener` had a bug where when declaring a queue binding for a subscriber, it would instantiate an exchange with no durability. 

Additionally, the call to the binding was incorrect.